### PR TITLE
Update cistarget.nf

### DIFF
--- a/src/scenic/processes/cistarget.nf
+++ b/src/scenic/processes/cistarget.nf
@@ -45,7 +45,6 @@ process CISTARGET {
             --expression_mtx_fname ${filteredLoom} \
             --cell_id_attribute ${toolParams.cell_id_attribute} \
             --gene_attribute ${toolParams.gene_attribute} \
-            --mode ${toolParams.mode} \
             --output ${outputFileName} \
             --num_workers ${task.cpus} \
         """


### PR DESCRIPTION
Took out mode option. Otherwise would not run and end with the following error: if len(dfs) == 0: # type: ignore TypeError: object of type 'generator' has no len()